### PR TITLE
Inline functions for creating type class dictionaries

### DIFF
--- a/directives.txt
+++ b/directives.txt
@@ -1,3 +1,15 @@
+FRP.Event.compactableEvent arity=1
+FRP.Event.filterableEvent arity=1
+FRP.Event.altEvent arity=1
+FRP.Event.plusEvent arity=1
+FRP.Event.applyEvent arity=1
+FRP.Event.applicativeEvent arity=1
+FRP.Event.eventIsEvent arity=1
+FRP.Event.semigroupEvent arity=2
+FRP.Event.monoidEvent arity=2
+FRP.Event.heytingAlgebraEvent arity=2
+FRP.Event.semiringEvent arity=2
+FRP.Event.ringEvent arity=2
 FRP.Event.applicativeEvent.pure arity=1
 FRP.Event.eventIsEvent.keepLatest arity=1
 FRP.Event.altEvent.alt arity=2


### PR DESCRIPTION
Not sure if this works/helps, but this is generally the pattern you'd follow for inlining the creation of the type class dictionaries themselves.

I'd enable a few at a time on a simple example and verify that from there.

Cheatsheet:
```
module.path.tyClassInstanceName arity=numOfTypeClassConstraints
```